### PR TITLE
Fix install-gnome-backgrounds.sh --screen argument

### DIFF
--- a/install-gnome-backgrounds.sh
+++ b/install-gnome-backgrounds.sh
@@ -189,7 +189,7 @@ fi
 install_wallpaper() {
   echo
   for theme in "${themes[@]}"; do
-    for screen in "${screens[2]}"; do
+    for screen in "${screens[@]}"; do
       install "$theme" "$screen"
     done
   done


### PR DESCRIPTION
${screens[2]} should be ${screens[@]} otherwise the --screen argument won't work.